### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/opendkim-operator/tests/integration/conftest.py
+++ b/opendkim-operator/tests/integration/conftest.py
@@ -100,9 +100,7 @@ def _replace_snap_on_unit(juju: jubilant.Juju, app_name: str) -> None:
             unit=unit_name,
             log=False,
         )
-        logger.info(
-            "Replaced opendkim snap on unit %s (machine %s)", unit_name, machine
-        )
+        logger.info("Replaced opendkim snap on unit %s (machine %s)", unit_name, machine)
 
 
 @pytest.fixture(scope="module", name="smtp_relay_app")

--- a/opendkim-operator/tests/integration/conftest.py
+++ b/opendkim-operator/tests/integration/conftest.py
@@ -35,10 +35,7 @@ def deploy_opendkim_fixture(
     deploy_opendkim_name = "opendkim"
 
     if not juju.status().apps.get(deploy_opendkim_name):
-        juju.deploy(
-            f"./{opendkim_charm}",
-            deploy_opendkim_name,
-        )
+        juju.deploy(f"./{opendkim_charm}", deploy_opendkim_name, log=False)
         # Wait for the charm to settle (blocked because not configured, or waiting).
         juju.wait(
             lambda status: (
@@ -61,7 +58,7 @@ def _configure_dns(juju: jubilant.Juju, unit_name: str) -> None:
         unit_name: The unit name.
     """
     dns_setup = "echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf.tail > /dev/null && sudo chattr -i /etc/resolv.conf 2>/dev/null || true && sudo cat /etc/resolv.conf.tail >> /etc/resolv.conf || true"
-    juju.exec(dns_setup, unit=unit_name)
+    juju.exec(dns_setup, unit=unit_name, log=False)
     logger.info("Configured DNS on unit %s", unit_name)
 
 
@@ -78,7 +75,8 @@ def _replace_snap_on_unit(juju: jubilant.Juju, app_name: str) -> None:
     snap_files = sorted(OPENDKIM_SNAP_DIR.glob("opendkim_*.snap"))
     if not snap_files:
         logger.warning(
-            "No locally-built opendkim snap found in %s; skipping replacement", OPENDKIM_SNAP_DIR
+            "No locally-built opendkim snap found in %s; skipping replacement",
+            OPENDKIM_SNAP_DIR,
         )
         return
 
@@ -100,8 +98,11 @@ def _replace_snap_on_unit(juju: jubilant.Juju, app_name: str) -> None:
             "--dangerous",
             f"/tmp/{snap_name}",  # nosec B108 — Juju copies resources to /tmp
             unit=unit_name,
+            log=False,
         )
-        logger.info("Replaced opendkim snap on unit %s (machine %s)", unit_name, machine)
+        logger.info(
+            "Replaced opendkim snap on unit %s (machine %s)", unit_name, machine
+        )
 
 
 @pytest.fixture(scope="module", name="smtp_relay_app")
@@ -113,7 +114,7 @@ def deploy_smtp_relay_fixture(
     smtp_relay_app_name = "smtp-relay"
 
     if not juju.status().apps.get(smtp_relay_app_name):
-        juju.deploy(smtp_relay_app_name, smtp_relay_app_name)
+        juju.deploy(smtp_relay_app_name, smtp_relay_app_name, log=False)
         juju.integrate(smtp_relay_app_name, opendkim_app)
         juju.wait(
             lambda status: (
@@ -126,7 +127,9 @@ def deploy_smtp_relay_fixture(
 
 
 @pytest.fixture(scope="session", name="juju")
-def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+def juju_fixture(
+    request: pytest.FixtureRequest,
+) -> Generator[jubilant.Juju, None, None]:
     """Pytest fixture that wraps :meth:`jubilant.with_model`."""
 
     def _show_debug_log(juju: jubilant.Juju):

--- a/opendkim-operator/tests/integration/test_charm.py
+++ b/opendkim-operator/tests/integration/test_charm.py
@@ -41,8 +41,12 @@ def generate_opendkim_genkey(domain: str, selector: str) -> typing.Tuple[str, st
             cwd=tmpdirname,
         )
         # Two files should have been created, {selector}.txt and {selector}.private
-        txt_data = (pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.txt")).read_text()
-        private_data = (pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.private")).read_text()
+        txt_data = (
+            pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.txt")
+        ).read_text()
+        private_data = (
+            pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.private")
+        ).read_text()
         return txt_data, private_data
 
 
@@ -92,7 +96,10 @@ def test_opendkim_signed_message(
 
     juju.cli("grant-secret", secret_id, opendkim_app)
     keytable = [
-        [f"{selector}._domainkey.{domain}", f"{domain}:{selector}:/etc/dkimkeys/{keyname}.private"]
+        [
+            f"{selector}._domainkey.{domain}",
+            f"{domain}:{selector}:/etc/dkimkeys/{keyname}.private",
+        ]
     ]
     signingtable = [[f"*@{domain}", f"{selector}._domainkey.{domain}"]]
     juju.config(
@@ -102,12 +109,15 @@ def test_opendkim_signed_message(
             "signingtable": json.dumps(signingtable),
             "private-keys": secret_id,
         },
+        log=False,
     )
 
-    command_to_put_domain = f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
-    juju.exec(machine=int(unit.machine), command=command_to_put_domain)
+    command_to_put_domain = (
+        f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
+    )
+    juju.exec(machine=int(unit.machine), command=command_to_put_domain, log=False)
 
-    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"})
+    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"}, log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, opendkim_app, smtp_relay_app),
         timeout=3 * 60,
@@ -136,16 +146,22 @@ This is my first message with Python."""
             break
         time.sleep(1)
     assert len(messages) == 1
-    message = requests.get(f"{mailcatcher_url}/{messages[0]['id']}.source", timeout=5).text
+    message = requests.get(
+        f"{mailcatcher_url}/{messages[0]['id']}.source", timeout=5
+    ).text
     logger.info("Message in mailcatcher: %s", message)
-    assert f"DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d={domain}" in message
+    assert (
+        f"DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d={domain}" in message
+    )
 
     # Clean up mailcatcher
     requests.delete(f"{mailcatcher_url}/{messages[0]['id']}", timeout=5)
 
 
 @pytest.mark.abort_on_fail
-def test_opendkim_testkey_failed_validation_(juju: jubilant.Juju, opendkim_app, smtp_relay_app):
+def test_opendkim_testkey_failed_validation_(
+    juju: jubilant.Juju, opendkim_app, smtp_relay_app
+):
     """
     arrange: Deploy opendkim and smtp-relay.
     act: OpenDKIM configuration is invalid as a key file is missing.
@@ -169,7 +185,10 @@ def test_opendkim_testkey_failed_validation_(juju: jubilant.Juju, opendkim_app, 
 
     juju.cli("grant-secret", secret_id, opendkim_app)
     keytable = [
-        [f"{selector}._domainkey.{domain}", f"{domain}:{selector}:/etc/dkimkeys/WRONGNAME.private"]
+        [
+            f"{selector}._domainkey.{domain}",
+            f"{domain}:{selector}:/etc/dkimkeys/WRONGNAME.private",
+        ]
     ]
     signingtable = [[f"*@{domain}", f"{selector}._domainkey.{domain}"]]
     juju.config(
@@ -179,22 +198,28 @@ def test_opendkim_testkey_failed_validation_(juju: jubilant.Juju, opendkim_app, 
             "signingtable": json.dumps(signingtable),
             "private-keys": secret_id,
         },
+        log=False,
     )
 
-    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"})
+    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"}, log=False)
     juju.wait(
         lambda status: (
-            status.apps[smtp_relay_app].is_active and status.apps[opendkim_app].is_blocked
+            status.apps[smtp_relay_app].is_active
+            and status.apps[opendkim_app].is_blocked
         ),
         timeout=3 * 60,
         delay=5,
     )
     status = juju.status()
-    assert "Wrong opendkim configuration" in status.apps[opendkim_app].app_status.message
+    assert (
+        "Wrong opendkim configuration" in status.apps[opendkim_app].app_status.message
+    )
 
 
 @pytest.mark.abort_on_fail
-def test_metrics_configured(juju: jubilant.Juju, opendkim_app, smtp_relay_app, machine_ip_address):
+def test_metrics_configured(
+    juju: jubilant.Juju, opendkim_app, smtp_relay_app, machine_ip_address
+):
     """
     arrange: Deploy opendkim.
     act: Get the metrics from the unit.
@@ -222,7 +247,10 @@ def test_metrics_configured(juju: jubilant.Juju, opendkim_app, smtp_relay_app, m
 
     juju.cli("grant-secret", secret_id, opendkim_app)
     keytable = [
-        [f"{selector}._domainkey.{domain}", f"{domain}:{selector}:/etc/dkimkeys/{keyname}.private"]
+        [
+            f"{selector}._domainkey.{domain}",
+            f"{domain}:{selector}:/etc/dkimkeys/{keyname}.private",
+        ]
     ]
     signingtable = [[f"*@{domain}", f"{selector}._domainkey.{domain}"]]
     juju.config(
@@ -232,12 +260,15 @@ def test_metrics_configured(juju: jubilant.Juju, opendkim_app, smtp_relay_app, m
             "signingtable": json.dumps(signingtable),
             "private-keys": secret_id,
         },
+        log=False,
     )
 
-    command_to_put_domain = f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
-    juju.exec(machine=int(unit.machine), command=command_to_put_domain)
+    command_to_put_domain = (
+        f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
+    )
+    juju.exec(machine=int(unit.machine), command=command_to_put_domain, log=False)
 
-    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"})
+    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"}, log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, opendkim_app, smtp_relay_app),
         timeout=3 * 60,
@@ -282,7 +313,10 @@ def test_opendkim_verify_mode_with_trusted_sources(
 
     juju.cli("grant-secret", secret_id, opendkim_app)
     keytable = [
-        [f"{selector}._domainkey.{domain}", f"{domain}:{selector}:/etc/dkimkeys/{keyname}.private"]
+        [
+            f"{selector}._domainkey.{domain}",
+            f"{domain}:{selector}:/etc/dkimkeys/{keyname}.private",
+        ]
     ]
     signingtable = [[f"*@{domain}", f"{selector}._domainkey.{domain}"]]
     trusted_sources = "10.0.0.0/8, 192.168.1.0/24, 172.16.0.0/12"
@@ -295,9 +329,10 @@ def test_opendkim_verify_mode_with_trusted_sources(
             "mode": "sv",
             "trusted-sources": trusted_sources,
         },
+        log=False,
     )
 
-    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"})
+    juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"}, log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, opendkim_app, smtp_relay_app),
         timeout=3 * 60,
@@ -308,7 +343,9 @@ def test_opendkim_verify_mode_with_trusted_sources(
     status = juju.status()
     opendkim_unit_name = next(iter(status.apps[opendkim_app].units))
     internalhosts_task = juju.exec(
-        "cat /var/snap/opendkim/current/etc/dkimkeys/internalhosts", unit=opendkim_unit_name
+        "cat /var/snap/opendkim/current/etc/dkimkeys/internalhosts",
+        unit=opendkim_unit_name,
+        log=False,
     )
     internalhosts_content = internalhosts_task.stdout.strip()
     assert "10.0.0.0/8" in internalhosts_content
@@ -317,7 +354,9 @@ def test_opendkim_verify_mode_with_trusted_sources(
 
     # Verify opendkim.conf references the internalhosts file
     opendkim_conf_task = juju.exec(
-        "cat /var/snap/opendkim/current/etc/opendkim.conf", unit=opendkim_unit_name
+        "cat /var/snap/opendkim/current/etc/opendkim.conf",
+        unit=opendkim_unit_name,
+        log=False,
     )
     opendkim_conf_content = opendkim_conf_task.stdout
     assert (

--- a/opendkim-operator/tests/integration/test_charm.py
+++ b/opendkim-operator/tests/integration/test_charm.py
@@ -41,12 +41,8 @@ def generate_opendkim_genkey(domain: str, selector: str) -> typing.Tuple[str, st
             cwd=tmpdirname,
         )
         # Two files should have been created, {selector}.txt and {selector}.private
-        txt_data = (
-            pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.txt")
-        ).read_text()
-        private_data = (
-            pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.private")
-        ).read_text()
+        txt_data = (pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.txt")).read_text()
+        private_data = (pathlib.Path(tmpdirname) / pathlib.Path(f"{selector}.private")).read_text()
         return txt_data, private_data
 
 
@@ -112,9 +108,7 @@ def test_opendkim_signed_message(
         log=False,
     )
 
-    command_to_put_domain = (
-        f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
-    )
+    command_to_put_domain = f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
     juju.exec(machine=int(unit.machine), command=command_to_put_domain, log=False)
 
     juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"}, log=False)
@@ -146,22 +140,16 @@ This is my first message with Python."""
             break
         time.sleep(1)
     assert len(messages) == 1
-    message = requests.get(
-        f"{mailcatcher_url}/{messages[0]['id']}.source", timeout=5
-    ).text
+    message = requests.get(f"{mailcatcher_url}/{messages[0]['id']}.source", timeout=5).text
     logger.info("Message in mailcatcher: %s", message)
-    assert (
-        f"DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d={domain}" in message
-    )
+    assert f"DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d={domain}" in message
 
     # Clean up mailcatcher
     requests.delete(f"{mailcatcher_url}/{messages[0]['id']}", timeout=5)
 
 
 @pytest.mark.abort_on_fail
-def test_opendkim_testkey_failed_validation_(
-    juju: jubilant.Juju, opendkim_app, smtp_relay_app
-):
+def test_opendkim_testkey_failed_validation_(juju: jubilant.Juju, opendkim_app, smtp_relay_app):
     """
     arrange: Deploy opendkim and smtp-relay.
     act: OpenDKIM configuration is invalid as a key file is missing.
@@ -204,22 +192,17 @@ def test_opendkim_testkey_failed_validation_(
     juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"}, log=False)
     juju.wait(
         lambda status: (
-            status.apps[smtp_relay_app].is_active
-            and status.apps[opendkim_app].is_blocked
+            status.apps[smtp_relay_app].is_active and status.apps[opendkim_app].is_blocked
         ),
         timeout=3 * 60,
         delay=5,
     )
     status = juju.status()
-    assert (
-        "Wrong opendkim configuration" in status.apps[opendkim_app].app_status.message
-    )
+    assert "Wrong opendkim configuration" in status.apps[opendkim_app].app_status.message
 
 
 @pytest.mark.abort_on_fail
-def test_metrics_configured(
-    juju: jubilant.Juju, opendkim_app, smtp_relay_app, machine_ip_address
-):
+def test_metrics_configured(juju: jubilant.Juju, opendkim_app, smtp_relay_app, machine_ip_address):
     """
     arrange: Deploy opendkim.
     act: Get the metrics from the unit.
@@ -263,9 +246,7 @@ def test_metrics_configured(
         log=False,
     )
 
-    command_to_put_domain = (
-        f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
-    )
+    command_to_put_domain = f"echo {machine_ip_address} {domain} | sudo tee -a /etc/hosts"
     juju.exec(machine=int(unit.machine), command=command_to_put_domain, log=False)
 
     juju.config(smtp_relay_app, {"relay_domains": f"- {domain}"}, log=False)


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.