### PR TITLE
Add landing page for reference docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-17
+
+- Added landing page for docs/reference.
+
 ## 2025-12-17
 
 - Moved charm-architecture.md from Explanation to Reference category.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,42 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Technical reference documentation for the OpenDKIM charm, including actions, configurations, and architecture."
+---
+
+(reference_index)=
+
+# Reference
+
+This section contains technical details and information about the `opendkim` charm.
+
+## Charm usage
+
+The following pages provide more information about the charm's features,
+including actions, configurations, and integrations.
+
+```{toctree}
+:maxdepth: 1
+actions
+configurations
+integrations
+```
+
+## Architecture and deployments
+
+The following pages provide more details about the charm architecture and
+a high-level deployment with any required dependencies.
+
+```{toctree}
+:maxdepth: 1
+charm-architecture
+```
+
+## Advanced topics
+
+The following page provides advanced-level topic on metrics.
+
+```{toctree}
+:maxdepth: 1
+metrics
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -22,21 +22,8 @@ configurations
 integrations
 ```
 
-## Architecture and deployments
-
-The following pages provide more details about the charm architecture and
-a high-level deployment with any required dependencies.
-
-```{toctree}
-:maxdepth: 1
-charm-architecture
-```
-
 ## Advanced topics
 
-The following page provides advanced-level topic on metrics.
+The following pages provide more details about the charm architecture,
+a high-level deployment with any required dependencies, and metrics.
 
-```{toctree}
-:maxdepth: 1
-metrics
-```


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add a landing page for references.

### Rationale

<!-- The reason the change is needed -->

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
