### PR TITLE
chore(docs): Add missing toctree element to reference index page

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -27,3 +27,8 @@ integrations
 The following pages provide more details about the charm architecture,
 a high-level deployment with any required dependencies, and metrics.
 
+```{toctree}
+:maxdepth: 1
+charm-architecture
+metrics
+```


### PR DESCRIPTION
### Overview

Add missing toctree element to reference index page.

### Rationale

Change suggested in https://github.com/canonical/opendkim-operator/pull/74 with the intent of incorporating the full suggestion, but the portion of the suggestion was omitted from the commit.

Looks like GitHub suggestions do not work as expected -- this is the second time I've noticed a suggestion not being fully incorporated in a PR. For both PRs, the suggestions contained a piece with three backticks ( ` ``` ` ), and both suggestions omitted this piece from the corresponding commit.

In the future I will not use GitHub's suggestions feature and instead type out the suggestion manually for the PR author to consider and incorporate on their own.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
