### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -4,11 +4,14 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+    - main
 
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      actions: read
+      contents: write
     secrets: inherit
     with:
       channel: 2/edge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit
     with:
       self-hosted-runner: true


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.